### PR TITLE
Add run_plot_match argument to associate_transient()

### DIFF
--- a/src/astro_prost/associate.py
+++ b/src/astro_prost/associate.py
@@ -265,6 +265,7 @@ def associate_transient(
     calc_host_props=False,
     verbose=0,
     coord_err_cols=('ra_err', 'dec_err'),
+    run_plot_match=False,
 ):
     """Associates a transient with its most likely host galaxy.
 
@@ -299,6 +300,8 @@ def associate_transient(
         The verbosity level of the output.
     coord_err_cols : tuple of strings
         The column names associated with positional uncertainties on the transient positions.
+    run_plot_match : boolean, optional
+        If true, attempts to generate a plot image.
 
     Returns
     -------
@@ -438,7 +441,10 @@ def associate_transient(
                         f"and RA, DEC = {result['host_ra']:.6f}, {result['host_dec']:.6f}"
                     )
 
-                if logger.getEffectiveLevel() == logging.DEBUG:
+                # For some reason the value of "verbose" is ignored here, and the effective
+                # level returned by logger.getEffectiveLevel() is 10 (DEBUG)
+                logger.info(f'''Effective logger level: {logger.getEffectiveLevel()}''')
+                if run_plot_match and logger.getEffectiveLevel() == logging.DEBUG:
                     try:
                         plot_match(
                             [result["host_ra"]],

--- a/src/astro_prost/diagnose.py
+++ b/src/astro_prost/diagnose.py
@@ -130,9 +130,10 @@ def get_ps1_pic(path, objid, ra, dec, size, band, safe=False, save=False):
 
         with fits.open(fitsurl) as fn:
             if save:
-                filename = f"/PS1_{objid}_{int(size*0.25)}arcsec_{band}.fits" if safe else \
-                           f"/PS1_ra={ra}_dec={dec}_{int(size*0.25)}arcsec_{band}.fits"
-                fn.writeto(path + filename, overwrite=True)
+                filename = f"PS1_{objid}_{int(size*0.25)}arcsec_{band}.fits" if safe else \
+                           f"PS1_ra={ra}_dec={dec}_{int(size*0.25)}arcsec_{band}.fits"
+                file_path = os.path.join(path, filename)
+                fn.writeto(file_path, overwrite=True)
             else:
                 return fn
     elif not save:


### PR DESCRIPTION
Add `run_plot_match` argument to `associate_transient()` to prevent invoking `plot_match()` when debugging is enabled. This generates errors when running Prost in another environment such as the Celery worker processes we use for [Blast](https://github.com/scimma/blast/) transient workflows. In my testing, even when the log level was explicitly set to INFO or WARNING via the `verbose` argument, the effective level returned by `logger.getEffectiveLevel()` was 10 (DEBUG) and the `plot_match()` function was called.

@alexandergagliano This hack is not necessarily the best solution to this problem, but in order for us to use Prost,  `plot_match()`  must be avoided.

@djones1040